### PR TITLE
adds an operationReducer factory function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,15 @@ export const walkState = (locationStack =[], state, initializer) => {
   }, state);
 };
 
+export const operationReducerFactory = (defaultState, reducerObject)=>
+  (state=defaultState, action) => {
+    if (action.type !== INIT_REDUX_OPERATIONS) return state;
+    return {
+      ...reducerObject,
+      signature: '@@reduxOperations'
+    }
+  }
+
 const appendChangeToState = (locationStack, state, newSubState) => {
   if (locationStack.length === 1) {
     return Object.assign({}, state, {[locationStack[0]]: newSubState});


### PR DESCRIPTION
adds an operationReducer factory function to make creation of redux-operations reducers easier and more intuitive 
tested with our redux-operations-counter-example the change is easy and makes the code look better and more understandable
