### PR TITLE
bug fix: when using a reducer with a dynamic location in state that i…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ const appendChangeToState = (locationInState, state, newSubState) => {
   if (locationInState.length === 1) {
     return {...state, [nextLocation]: newSubState};
   } else {
-    const subObject = appendChangeToState(locationInState.slice(1), state[nextLocation], newSubState);
+    const subObject = appendChangeToState(locationInState.slice(1), state[nextLocation] || {}, newSubState);
     return {...state, [nextLocation]: subObject}
   }
 };


### PR DESCRIPTION
when using a reducer with a dynamic location in state that is more than two level lower than an existing state.

For example - ["counters","top"] always worked for a state that did not have "counters" object. But  ["counters","top","1"] did not work.
 With this fix it does
